### PR TITLE
Add Newline String Option

### DIFF
--- a/Sources/TextFormation/NewlineProcessingFilter.swift
+++ b/Sources/TextFormation/NewlineProcessingFilter.swift
@@ -4,8 +4,8 @@ import TextStory
 public class NewlineProcessingFilter {
     private let recognizer: ConsecutiveCharacterRecognizer
 
-    public init() {
-        self.recognizer = ConsecutiveCharacterRecognizer(matching: "\n")
+    public init(newline: String = "\n") {
+        self.recognizer = ConsecutiveCharacterRecognizer(matching: newline)
     }
 
     private func filterHandler(_ mutation: TextMutation, in interface: TextInterface, with providers: WhitespaceProviders) -> FilterAction {

--- a/Tests/TextFormationTests/NewlineProcessingFilterTests.swift
+++ b/Tests/TextFormationTests/NewlineProcessingFilterTests.swift
@@ -68,4 +68,41 @@ final class NewlineProcessingFilterTests: XCTestCase {
 		XCTAssertEqual(interface.string, "\t\n\t\n\t")
 		XCTAssertEqual(interface.insertionLocation, 5)
 	}
+
+    func testMatchingWithUnknownNewline() {
+        let interface = TextInterfaceAdapter("")
+        let filter = NewlineProcessingFilter(newline: "crlf")
+
+        let mutation = TextMutation(insert: "crlf", at: 0, limit: 0)
+
+        XCTAssertEqual(filter.processMutation(mutation, in: interface, with: Self.providers), .discard)
+
+        XCTAssertEqual(interface.string, "crlf\t")
+        XCTAssertEqual(interface.insertionLocation, 5)
+    }
+
+    func testMatchingWithUnknownNewlineAndTrailingWhitespace() {
+        let interface = TextInterfaceAdapter(" ")
+        let filter = NewlineProcessingFilter(newline: "crlf")
+
+        let mutation = TextMutation(insert: "crlf", at: 1, limit: 1)
+
+        XCTAssertEqual(interface.insertionLocation, 1)
+        XCTAssertEqual(filter.processMutation(mutation, in: interface, with: Self.providers), .discard)
+
+        XCTAssertEqual(interface.string, " crlf\t")
+        XCTAssertEqual(interface.insertionLocation, 6)
+    }
+
+    func testMatchingWithUnknownNewlineAndTrailingTab() {
+        let interface = TextInterfaceAdapter("abc\t")
+        let filter = NewlineProcessingFilter(newline: "crlf")
+
+        let mutation = TextMutation(insert: "crlf", at: 4, limit: 4)
+
+        XCTAssertEqual(filter.processMutation(mutation, in: interface, with: Self.providers), .discard)
+
+        XCTAssertEqual(interface.string, "abc crlf\t")
+        XCTAssertEqual(interface.insertionLocation, 9)
+    }
 }


### PR DESCRIPTION
Adds the ability to set the newline string used by the `NewlineProcessingFilter` to detect newlines when initializing. For example, when editing a file with carriage return `\r` newlines instead of the default  linefeed `\n`.