### PR TITLE
Maybe fix some concurrency warnings

### DIFF
--- a/Sources/TextFormation/TextualIndenter+Language.swift
+++ b/Sources/TextFormation/TextualIndenter+Language.swift
@@ -1,65 +1,71 @@
 import Foundation
 
 public extension TextualIndenter {
-    static let basicPatterns: [PatternMatcher] = [
-        CurrentLinePrefixOutdenter(prefix: "}"),
-        CurrentLinePrefixOutdenter(prefix: ")"),
-        CurrentLinePrefixOutdenter(prefix: "]"),
+	static var basicPatterns: [PatternMatcher] {
+		[
+			CurrentLinePrefixOutdenter(prefix: "}"),
+			CurrentLinePrefixOutdenter(prefix: ")"),
+			CurrentLinePrefixOutdenter(prefix: "]"),
 
-        PreceedingLinePrefixIndenter(prefix: "{"),
-        PreceedingLinePrefixIndenter(prefix: "("),
-        PreceedingLinePrefixIndenter(prefix: "["),
+			PreceedingLinePrefixIndenter(prefix: "{"),
+			PreceedingLinePrefixIndenter(prefix: "("),
+			PreceedingLinePrefixIndenter(prefix: "["),
 
-        PreceedingLineSuffixIndenter(suffix: "{"),
-        PreceedingLineSuffixIndenter(suffix: "("),
-        PreceedingLineSuffixIndenter(suffix: "["),
-    ]
+			PreceedingLineSuffixIndenter(suffix: "{"),
+			PreceedingLineSuffixIndenter(suffix: "("),
+			PreceedingLineSuffixIndenter(suffix: "["),
+		]
+	}
 }
 
 public extension TextualIndenter {
 	/// Specialized indentation patterns for Ruby.
-    static let rubyPatterns: [PatternMatcher] = [
-        CurrentLinePrefixOutdenter(prefix: "else"),
-        CurrentLinePrefixOutdenter(prefix: "elsif"),
-        CurrentLinePrefixOutdenter(prefix: "ensure"),
-        CurrentLinePrefixOutdenter(prefix: "rescue"),
-        CurrentLinePrefixOutdenter(prefix: "when"),
-        CurrentLinePrefixOutdenter(prefix: "end"),
+	static var rubyPatterns: [PatternMatcher] {
+		[
+			CurrentLinePrefixOutdenter(prefix: "else"),
+			CurrentLinePrefixOutdenter(prefix: "elsif"),
+			CurrentLinePrefixOutdenter(prefix: "ensure"),
+			CurrentLinePrefixOutdenter(prefix: "rescue"),
+			CurrentLinePrefixOutdenter(prefix: "when"),
+			CurrentLinePrefixOutdenter(prefix: "end"),
 
-        PreceedingLinePrefixIndenter(prefix: "{"),
-        PreceedingLinePrefixIndenter(prefix: "("),
-        PreceedingLinePrefixIndenter(prefix: "["),
+			PreceedingLinePrefixIndenter(prefix: "{"),
+			PreceedingLinePrefixIndenter(prefix: "("),
+			PreceedingLinePrefixIndenter(prefix: "["),
 
-        PreceedingLineSuffixIndenter(suffix: "{"),
-        PreceedingLineSuffixIndenter(suffix: "("),
-        PreceedingLineSuffixIndenter(suffix: "["),
-        PreceedingLineSuffixIndenter(suffix: "|"),
-        PreceedingLineSuffixIndenter(suffix: "do"),
+			PreceedingLineSuffixIndenter(suffix: "{"),
+			PreceedingLineSuffixIndenter(suffix: "("),
+			PreceedingLineSuffixIndenter(suffix: "["),
+			PreceedingLineSuffixIndenter(suffix: "|"),
+			PreceedingLineSuffixIndenter(suffix: "do"),
 
-        PreceedingLinePrefixIndenter(prefix: "if"),
-        PreceedingLinePrefixIndenter(prefix: "else"),
-        PreceedingLinePrefixIndenter(prefix: "elsif"),
-        PreceedingLinePrefixIndenter(prefix: "ensure"),
-        PreceedingLinePrefixIndenter(prefix: "rescue"),
-        PreceedingLinePrefixIndenter(prefix: "when"),
-        PreceedingLinePrefixIndenter(prefix: "for"),
-        PreceedingLinePrefixIndenter(prefix: "unless"),
-        PreceedingLinePrefixIndenter(prefix: "while"),
-        PreceedingLinePrefixIndenter(prefix: "class"),
-        PreceedingLinePrefixIndenter(prefix: "module"),
-        PreceedingLinePrefixIndenter(prefix: "def"),
-    ]
+			PreceedingLinePrefixIndenter(prefix: "if"),
+			PreceedingLinePrefixIndenter(prefix: "else"),
+			PreceedingLinePrefixIndenter(prefix: "elsif"),
+			PreceedingLinePrefixIndenter(prefix: "ensure"),
+			PreceedingLinePrefixIndenter(prefix: "rescue"),
+			PreceedingLinePrefixIndenter(prefix: "when"),
+			PreceedingLinePrefixIndenter(prefix: "for"),
+			PreceedingLinePrefixIndenter(prefix: "unless"),
+			PreceedingLinePrefixIndenter(prefix: "while"),
+			PreceedingLinePrefixIndenter(prefix: "class"),
+			PreceedingLinePrefixIndenter(prefix: "module"),
+			PreceedingLinePrefixIndenter(prefix: "def"),
+		]
+	}
 
 	/// Specialized indentation patterns for Python.
-	static let pythonPatterns: [PatternMatcher] = [
-		PreceedingLineSuffixIndenter(suffix: ":"),
+	static var pythonPatterns: [PatternMatcher] {
+		[
+			PreceedingLineSuffixIndenter(suffix: ":"),
 
-		PreceedingLinePrefixIndenter(prefix: "{"),
-		PreceedingLinePrefixIndenter(prefix: "("),
-		PreceedingLinePrefixIndenter(prefix: "["),
+			PreceedingLinePrefixIndenter(prefix: "{"),
+			PreceedingLinePrefixIndenter(prefix: "("),
+			PreceedingLinePrefixIndenter(prefix: "["),
 
-		PreceedingLineSuffixIndenter(suffix: "{"),
-		PreceedingLineSuffixIndenter(suffix: "("),
-		PreceedingLineSuffixIndenter(suffix: "["),
-	]
+			PreceedingLineSuffixIndenter(suffix: "{"),
+			PreceedingLineSuffixIndenter(suffix: "("),
+			PreceedingLineSuffixIndenter(suffix: "["),
+		]
+	}
 }

--- a/Sources/TextFormation/WhitespaceProviders.swift
+++ b/Sources/TextFormation/WhitespaceProviders.swift
@@ -18,9 +18,14 @@ public struct WhitespaceProviders {
 }
 
 extension WhitespaceProviders {
-    public static let passthroughProvider: StringSubstitutionProvider = { $1.substring(from: $0) ?? "" }
-    public static let removeAllProvider: StringSubstitutionProvider =  { _, _ in return "" }
-
-    public static let none = WhitespaceProviders(leadingWhitespace: WhitespaceProviders.passthroughProvider,
-                                                 trailingWhitespace: WhitespaceProviders.passthroughProvider)
+	public static var passthroughProvider: StringSubstitutionProvider {
+		{ $1.substring(from: $0) ?? "" }
+	}
+	public static var removeAllProvider: StringSubstitutionProvider {
+		{ _, _ in return "" }
+	}
+	public static var none: WhitespaceProviders {
+		WhitespaceProviders(leadingWhitespace: WhitespaceProviders.passthroughProvider,
+							trailingWhitespace: WhitespaceProviders.passthroughProvider)
+	}
 }


### PR DESCRIPTION
Forgive me if this is the wrong approach, still wrapping my head around some of this stuff. (Thanks for all the great resources btw!) The gist of the PR is changing stored `static let`s to computed `static var`s.

I think Xcode also reformatted according to the .editorconfig? Let me know if you don't want those changes as part of this, I'm happy to remove them if so.

| Before | After |
|--------|-------|
| <img width="551" alt="Screenshot 2024-06-12 at 11 32 42 AM" src="https://github.com/ChimeHQ/TextFormation/assets/483/927e523a-80da-4331-b957-0de8a233e195"> | <img width="563" alt="Screenshot 2024-06-12 at 11 32 57 AM" src="https://github.com/ChimeHQ/TextFormation/assets/483/15db89ee-6eea-4016-a09d-e584755e174e"> |




